### PR TITLE
Update link to webchat documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ ruby app.rb
 
 The javascript and html side of this api is documented here.
 
-https://github.com/alphagov/government-frontend/tree/master/app/assets/javascripts/webchat
+https://github.com/alphagov/government-frontend/blob/master/docs/webchat.md


### PR DESCRIPTION
The file has been moved so this updates the link to it. 

[Trello card](https://trello.com/c/I3TceC4t/1472-update-link-in-webchat-documentation)